### PR TITLE
fixed the out-of-balance Connected HSS header, also hooked up the def…

### DIFF
--- a/src/mme_app/mme_app_bearer.c
+++ b/src/mme_app/mme_app_bearer.c
@@ -917,7 +917,8 @@ mme_app_handle_delete_session_rsp (
    */
   mme_app_desc.mme_ue_contexts.nb_bearers_managed--;
   mme_app_desc.mme_ue_contexts.nb_bearers_since_last_stat--;
-
+  update_mme_app_stats_default_bearer_sub();
+  
   /**
    * Object is later removed, not here. For unused keys, this is no problem, just deregistrate the tunnel ids for the MME_APP
    * UE context from the hashtable.

--- a/src/mme_app/mme_app_pdn_context.c
+++ b/src/mme_app/mme_app_pdn_context.c
@@ -662,6 +662,8 @@ mme_app_pdn_process_session_creation(mme_ue_s1ap_id_t ue_id, fteid_t * saegw_s11
        */
       mme_app_desc.mme_ue_contexts.nb_bearers_managed++;
       mme_app_desc.mme_ue_contexts.nb_bearers_since_last_stat++;
+      update_mme_app_stats_default_bearer_add();
+
       /** Update the FTEIDs of the SAE-GW. */
       memcpy(&bearer_context->s_gw_fteid_s1u, &bcs_created->bearer_contexts[i].s1u_sgw_fteid, sizeof(fteid_t)); /**< Also copying the IPv4/V6 address. */
       memcpy(&bearer_context->p_gw_fteid_s5_s8_up, &bcs_created->bearer_contexts[i].s5_s8_u_pgw_fteid, sizeof(fteid_t));

--- a/src/mme_app/mme_app_statistics.c
+++ b/src/mme_app/mme_app_statistics.c
@@ -43,7 +43,7 @@ int mme_app_statistics_display (
   void)
 {
   OAILOG_DEBUG (LOG_MME_APP, "======================================= STATISTICS ============================================\n\n");
-  OAILOG_DEBUG (LOG_MME_APP, "               |  Current Status |  Added since last display  |  Removed since last display |\n");
+  OAILOG_DEBUG (LOG_MME_APP, "               |  Current Status |  Added since last display   |  Removed since last display |\n");
   OAILOG_DEBUG (LOG_MME_APP, "Connected HSS  | %10u      |            (N/A)            |           (N/A)             |\n", hss_associated);
   OAILOG_DEBUG (LOG_MME_APP, "Connected eNBs | %10u      |     %10u              |    %10u               |\n",mme_app_desc.nb_enb_connected,
                                           mme_app_desc.nb_enb_connected_since_last_stat,mme_app_desc.nb_enb_released_since_last_stat);

--- a/src/mme_app/mme_app_statistics.c
+++ b/src/mme_app/mme_app_statistics.c
@@ -43,7 +43,7 @@ int mme_app_statistics_display (
   void)
 {
   OAILOG_DEBUG (LOG_MME_APP, "======================================= STATISTICS ============================================\n\n");
-  OAILOG_DEBUG (LOG_MME_APP, "               |   Current Status| Added since last display|  Removed since last display |\n");
+  OAILOG_DEBUG (LOG_MME_APP, "               |  Current Status |  Added since last display  |  Removed since last display |\n");
   OAILOG_DEBUG (LOG_MME_APP, "Connected HSS  | %10u      |            (N/A)            |           (N/A)             |\n", hss_associated);
   OAILOG_DEBUG (LOG_MME_APP, "Connected eNBs | %10u      |     %10u              |    %10u               |\n",mme_app_desc.nb_enb_connected,
                                           mme_app_desc.nb_enb_connected_since_last_stat,mme_app_desc.nb_enb_released_since_last_stat);

--- a/src/mme_app/mme_app_statistics.c
+++ b/src/mme_app/mme_app_statistics.c
@@ -44,7 +44,7 @@ int mme_app_statistics_display (
 {
   OAILOG_DEBUG (LOG_MME_APP, "======================================= STATISTICS ============================================\n\n");
   OAILOG_DEBUG (LOG_MME_APP, "               |   Current Status| Added since last display|  Removed since last display |\n");
-  OAILOG_DEBUG (LOG_MME_APP, "Connected HSS  | %10u      |     (N/A)             |    (N/A)              |\n", hss_associated);
+  OAILOG_DEBUG (LOG_MME_APP, "Connected HSS  | %10u      |            (N/A)            |           (N/A)             |\n", hss_associated);
   OAILOG_DEBUG (LOG_MME_APP, "Connected eNBs | %10u      |     %10u              |    %10u               |\n",mme_app_desc.nb_enb_connected,
                                           mme_app_desc.nb_enb_connected_since_last_stat,mme_app_desc.nb_enb_released_since_last_stat);
   OAILOG_DEBUG (LOG_MME_APP, "Attached UEs   | %10u      |     %10u              |    %10u               |\n",mme_app_desc.nb_ue_attached,


### PR DESCRIPTION
Two quick bug-fixes that affect how the MME prints its stats every 10 seconds:
- Bearers weren't being counted when added/subtracted
- the Connected HSS line was slightly mis-formatted and drove me crazy